### PR TITLE
MapFragment  실행 시 현재 위치를 가져오도록 수정 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,7 +16,7 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
-    dataBinding{
+    dataBinding {
         enabled = true
     }
 }
@@ -44,6 +44,13 @@ dependencies {
 
     // 로그 출력
     implementation 'com.jakewharton.timber:timber:4.7.1'
+
+    // 구글맵 라이브러리 
     implementation 'com.google.android.gms:play-services-location:16.0.0'
     implementation 'com.google.android.libraries.places:places:1.0.0'
+
+    // 메모리릭 검출 라이브러리
+    debugImplementation 'com.squareup.leakcanary:leakcanary-android:1.5.4'
+    releaseImplementation 'com.squareup.leakcanary:leakcanary-android:1.5.4'
+    testImplementation 'com.squareup.leakcanary:leakcanary-android:1.5.4'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,9 +2,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.share.greencloud">
 
-    <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
-
     <application
         android:name=".kakaologin.GlobalApplication"
         android:allowBackup="true"
@@ -13,7 +10,6 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-
         <activity
             android:name=".kakaologin.KakaoLoginActiviy"
             android:launchMode="singleTop">
@@ -23,7 +19,6 @@
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </activity>
-
         <activity android:name=".MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -32,18 +27,22 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-
         <activity android:name=".activity.LayoutListActivity" />
         <activity android:name=".googlelogin.GoogleLoginActivity" />
+
         <meta-data
             android:name="com.kakao.sdk.AppKey"
             android:value="@string/kakao_app_key" />
         <meta-data
             android:name="com.google.android.geo.API_KEY"
             android:value="@string/google_maps_key" />
+
         <uses-library
             android:name="org.apache.http.legacy"
             android:required="false" />
     </application>
+    <uses-permission android:name="android.permission.INTERNET" />
+
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
 </manifest>

--- a/app/src/main/java/com/share/greencloud/activity/LayoutListActivity.java
+++ b/app/src/main/java/com/share/greencloud/activity/LayoutListActivity.java
@@ -1,14 +1,20 @@
 package com.share.greencloud.activity;
 
+import android.Manifest;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.v4.app.ActivityCompat;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentPagerAdapter;
+import android.support.v4.content.ContextCompat;
 import android.support.v4.view.ViewPager;
 import android.support.v7.app.AppCompatActivity;
+import android.widget.Toast;
 
 import com.share.greencloud.R;
 import com.share.greencloud.fragment.CameraFragment;
@@ -22,6 +28,8 @@ import com.share.greencloud.fragment.MapFragment;
 import com.share.greencloud.fragment.MyGreenFragment;
 import com.share.greencloud.googlelogin.GoogleLoginActivity;
 import com.share.greencloud.kakaologin.KakaoLoginActiviy;
+
+import timber.log.Timber;
 
 public class LayoutListActivity extends AppCompatActivity implements LayoutListFragment.CommunicateListener,
         GreenCloudInfoFragment.OnFragmentInteractionListener,
@@ -37,6 +45,9 @@ public class LayoutListActivity extends AppCompatActivity implements LayoutListF
 
     LoginFragment loginFragment;
 
+    private static final int PERMISSIONS_REQUEST_ACCESS_FINE_LOCATION = 1;
+    private boolean mLocationPermissionGranted;
+
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -45,6 +56,11 @@ public class LayoutListActivity extends AppCompatActivity implements LayoutListF
 
         vp = findViewById(R.id.vp);
         vp.setAdapter(new VpAdt(getSupportFragmentManager()));
+
+        if (!checkPermissions()) {
+            getLocationPermission();
+        }
+
     }
 
     @Override
@@ -138,5 +154,56 @@ public class LayoutListActivity extends AppCompatActivity implements LayoutListF
 
         if (loginFragment != null)
             loginFragment.onActivityResult(requestCode, resultCode, data);
+    }
+
+    private boolean checkPermissions() {
+        int permissionState = ActivityCompat.checkSelfPermission(this,
+                Manifest.permission.ACCESS_FINE_LOCATION);
+        return permissionState == PackageManager.PERMISSION_GRANTED;
+    }
+
+    private void getLocationPermission() {
+        /*
+         * Request location permission, so that we can get the location of the
+         * device. The result of the permission request is handled by a callback,
+         * onRequestPermissionsResult.
+         */
+        if (ContextCompat.checkSelfPermission(this.getApplicationContext(),
+                android.Manifest.permission.ACCESS_FINE_LOCATION)
+                == PackageManager.PERMISSION_GRANTED) {
+            mLocationPermissionGranted = true;
+        } else {
+            ActivityCompat.requestPermissions(this,
+                    new String[]{android.Manifest.permission.ACCESS_FINE_LOCATION},
+                    PERMISSIONS_REQUEST_ACCESS_FINE_LOCATION);
+        }
+    }
+
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode,
+                                           @NonNull String permissions[],
+                                           @NonNull int[] grantResults) {
+        Timber.d("onRequestPermissionsResult() is called");
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+
+        mLocationPermissionGranted = false;
+        switch (requestCode) {
+            case PERMISSIONS_REQUEST_ACCESS_FINE_LOCATION: {
+                // If request is cancelled, the result arrays are empty.
+                if (grantResults.length > 0
+                        && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                    mLocationPermissionGranted = true;
+                }
+                else {
+                    Toast.makeText(this, "위치정보 사용에 대한 동의가 거부되었습니다.", Toast.LENGTH_SHORT).show();
+                }
+            }
+        }
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
     }
 }

--- a/app/src/main/java/com/share/greencloud/kakaologin/GlobalApplication.java
+++ b/app/src/main/java/com/share/greencloud/kakaologin/GlobalApplication.java
@@ -3,6 +3,8 @@ package com.share.greencloud.kakaologin;
 import android.app.Application;
 
 import com.kakao.auth.KakaoSDK;
+import com.squareup.leakcanary.LeakCanary;
+
 
 public class GlobalApplication extends Application {
     private static GlobalApplication instance;
@@ -22,6 +24,13 @@ public class GlobalApplication extends Application {
 
         // Kakao Sdk 초기화
         KakaoSDK.init(new KakaoSDKAdapter());
+
+        if (LeakCanary.isInAnalyzerProcess(this)) {
+            // This process is dedicated to LeakCanary for heap analysis.
+            // You should not init your app in this process.
+            return;
+        }
+        LeakCanary.install(this);
     }
 
     @Override

--- a/app/src/main/java/com/share/greencloud/lifecycleobserver/MyObserver.java
+++ b/app/src/main/java/com/share/greencloud/lifecycleobserver/MyObserver.java
@@ -1,0 +1,31 @@
+package com.share.greencloud.lifecycleobserver;
+
+import android.arch.lifecycle.Lifecycle;
+import android.arch.lifecycle.LifecycleObserver;
+import android.arch.lifecycle.LifecycleOwner;
+import android.arch.lifecycle.OnLifecycleEvent;
+import android.content.Context;
+
+import com.share.greencloud.kakaologin.GlobalApplication;
+
+import timber.log.Timber;
+
+public class MyObserver implements LifecycleObserver {
+    private final Context mContext;
+
+    public MyObserver(LifecycleOwner lifecycleOwner, Context context) {
+        mContext = context;
+        lifecycleOwner.getLifecycle().addObserver(this);
+    }
+
+    @OnLifecycleEvent(Lifecycle.Event.ON_RESUME)
+    public void onResume() {
+        Timber.d("onResume is called");
+    }
+
+    @OnLifecycleEvent(Lifecycle.Event.ON_PAUSE)
+    public void onPause() {
+    }
+}
+
+

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,0 +1,3 @@
+<resources>
+    <dimen name="fab_margin">16dp</dimen>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,4 +6,5 @@
 
     <!-- TODO: Remove or change this placeholder text -->
     <string name="hello_blank_fragment">Hello blank fragment</string>
+    <string name="title_activity_map">MapActivity</string>
 </resources>


### PR DESCRIPTION
* 작업내역 

1. MapFragment을 실행시키면 사용자의 현재 위치 가져오도록 수정
2. 사용자의 위치정보 동의권한은 parent Activity에서 실행되도록 수정 (Fragment에서 실행하면, onRequestPermissionsResult 함수가 실행되지 않아서 오류가 생기) 
3. 만약에 사용자가 위치정보 권한을 동의하지 않으면, 최초에 서울로 위치가 설정됨 (단, 다시 MapFragment을 실행하면 기본 위치가 바뀌는 오류가 있음) 